### PR TITLE
Task: CSS Bayan

### DIFF
--- a/cssBayan/style.css
+++ b/cssBayan/style.css
@@ -6,14 +6,10 @@ body {
   font-weight: 900;
   font-family: "Trebuchet MS", "Lucida Sans Unicode", "Lucida Grande",
     "Lucida Sans", Arial, sans-serif;
-  /* min-height: 100vh; */
   margin: 2rem;
 }
 
-/* p {
-  font-size: 3em;
-  font-weight: 1200;
-} */
+
 
 section {
   display: block;


### PR DESCRIPTION
1. Task: https://github.com/DrDiman/CSS-Bayan-task
2. Screenshot:
  ![cssBayan](https://user-images.githubusercontent.com/15693438/224538049-cfe21d4b-a036-4eb1-a1c6-334df0b742d5.png)

3. Deploy: https://zelenskiy.github.io/cssBayan/cssBayan/
4. Done 12.03.2023 / deadline 13.03.2023
5. Score: 135 / 140
- [x] Everything is done from Repository requirements and how to submit task section (30)
- [x] The accordion component is centered on the screen, with equal indents on the left and right (10)
- [x] Icons, meme texts and meme images are exist (5)
- [x] Placement of the meme, icons and meme text are the same as in provided example gif images (5)
- [x] Smooth change (transition) of the meme images and icons is done (20)
- [x] Responsive design with three breakpoints for mobile, tablet, and desktop exist. Accordion is displayed correctly at mobile 320x568, tablet 820x1180, desktop 1920×1080. (Note: breakpoints don't have to be 320x568, 820x1180, 1920x1080). (10)
- [±] All visual effects when the cursor is hovering over the memes, when the mouse is down on a meme, and when a meme is selected are implemented (5 / 10)
- [x] The entire row (text, icon, and meme image) clickable (5)
- [x] Cursor over the memes (hover) effect only exists for devices that can support hover. (10)
- [x] The cursor when it is hovering over the rows of the accordion is changing (5)
- [x] Only flexible dimensions are used rem, em, %, vh, vw, fr and etc... The accordion is responsive (10)
- [x] All blocks/parts of the accordion are in base flow of the dom elements. All elements are not positioned with top, left, right, bottom. float is not used. The value of position is only static (5)
- [x] Pseudo-elements are not used (note 1: pseudo-classes are allowed; note 2: pseudo-elements only from FontAwesome are allowed) (5)
- [x] Initially, the first meme should be expanded (5)
- [x] Font size is changed at each device (mobile, tablet, desktop) (5)

